### PR TITLE
bugfix: trace main thread only

### DIFF
--- a/samples/lj-lua-stacks.sxx
+++ b/samples/lj-lua-stacks.sxx
@@ -59,7 +59,7 @@ function process_event()
 
 probe $^arg_probe :default(timer.profile)
 {
-    if (pid() == target()) {
+    if (tid() == target()) {
         process_event()
     }
 }


### PR DESCRIPTION
When some new features are used, e.g. grpc-client-nginx-module, lua-resty-ffi, the nginx worker process has multiple threads.

CPU flamegraph is only meaningful for the main thread, which runs nginx event loop and lua code, so we should ignore other threads.

`tid()` gets the thread id, and in Linux, the process id is just equal to its main thread id, so we should use `tid()` to match `target()`.